### PR TITLE
Fix Constraints Auto Reloading

### DIFF
--- a/ConstraintsGrailsPlugin.groovy
+++ b/ConstraintsGrailsPlugin.groovy
@@ -72,6 +72,10 @@ class ConstraintsGrailsPlugin {
 
     def artefacts = [new ConstraintArtefactHandler()]
 
+    def watchedResources = [
+        "file:./grails-app/utils/*Constraint.groovy"
+    ]
+
     def doWithSpring = {
         // TODO Implement runtime spring config (optional)
         application.constraintClasses.each {constraintClass ->
@@ -96,10 +100,9 @@ class ConstraintsGrailsPlugin {
         // watching is modified and reloaded. The event contains: event.source,
         // event.application, event.manager, event.ctx, and event.plugin.
 
-        // XXX: Not sure if this works?
         if (application.isArtefactOfType(ConstraintArtefactHandler.TYPE, event.source)) {
-            setupConstraintProperties(event.source)
-            application.addArtefact(ConstraintArtefactHandler.TYPE, event.source)
+            def artefactClass = application.addArtefact(ConstraintArtefactHandler.TYPE, event.source)
+            setupConstraintProperties(artefactClass)
         }
     }
 


### PR DESCRIPTION
Hi Geoff,

Thank you very much for this excellent plugin.

This pull request adds reload support for Constraints artefacts, to do this the changes were pretty small, I just set up the plugin to watch for utils/*Constraint.groovy resources, and then tweaked the onChange handler a little bit to handle reconfiguring the artefacts.

This might need a little bit more work, as I'm not too sure about the way you're configuring the constraints beans for spring - I'm not sure if the re-registered artefacts will get picked up this way.

Let me know what you think! :)
