### PR TITLE
Extend custom validate method return types

### DIFF
--- a/grails-app/domain/net/zorched/test/HasExtendedValidators.groovy
+++ b/grails-app/domain/net/zorched/test/HasExtendedValidators.groovy
@@ -1,0 +1,11 @@
+package net.zorched.test
+
+class HasExtendedValidators {
+    String foo
+    String bar
+
+    static constraints = {
+        foo(errorCode: true)
+        bar(errorParams: true)
+    }
+}

--- a/grails-app/utils/net/zorched/test/ErrorCodeConstraint.groovy
+++ b/grails-app/utils/net/zorched/test/ErrorCodeConstraint.groovy
@@ -1,0 +1,7 @@
+package net.zorched.test
+
+class ErrorCodeConstraint {
+    def validate = { val ->
+        return "error.code"
+    }
+}

--- a/grails-app/utils/net/zorched/test/ErrorParamsConstraint.groovy
+++ b/grails-app/utils/net/zorched/test/ErrorParamsConstraint.groovy
@@ -1,0 +1,7 @@
+package net.zorched.test
+
+class ErrorParamsConstraint {
+    def validate = { val ->
+        return ["error.code", "foo", "bar"]
+    }
+}

--- a/src/java/net/zorched/grails/plugins/validation/DefaultGrailsConstraintClass.java
+++ b/src/java/net/zorched/grails/plugins/validation/DefaultGrailsConstraintClass.java
@@ -71,7 +71,8 @@ public class DefaultGrailsConstraintClass extends AbstractInjectableGrailsClass 
      * @return True if the validation passed or false if it failed.
      */
     public boolean validate(Object[] params) {
-        return (Boolean) getMetaClass().invokeMethod(getReferenceInstance(), VALIDATE, params);
+        Object result = getMetaClass().invokeMethod(getReferenceInstance(), VALIDATE, params);
+        return result != null ? (Boolean)result : true;
     }
 
     public int getValidationPropertyCount() {

--- a/src/java/net/zorched/grails/plugins/validation/DefaultGrailsConstraintClass.java
+++ b/src/java/net/zorched/grails/plugins/validation/DefaultGrailsConstraintClass.java
@@ -70,9 +70,8 @@ public class DefaultGrailsConstraintClass extends AbstractInjectableGrailsClass 
      * @param params The parameters to pass to the constraint closure
      * @return True if the validation passed or false if it failed.
      */
-    public boolean validate(Object[] params) {
-        Object result = getMetaClass().invokeMethod(getReferenceInstance(), VALIDATE, params);
-        return result != null ? (Boolean)result : true;
+    public Object validate(Object[] params) {
+        return getMetaClass().invokeMethod(getReferenceInstance(), VALIDATE, params);
     }
 
     public int getValidationPropertyCount() {

--- a/src/java/net/zorched/grails/plugins/validation/GrailsConstraintClass.java
+++ b/src/java/net/zorched/grails/plugins/validation/GrailsConstraintClass.java
@@ -48,7 +48,7 @@ public interface GrailsConstraintClass extends InjectableGrailsClass {
      * The validation method called
      * @return True if the constraint validates
      */
-    public boolean validate(Object[] params);
+    public Object validate(Object[] params);
 
     /**
      * Can the constraint be applied to a specific type?

--- a/test/integration/ExtendedValidatorTests.groovy
+++ b/test/integration/ExtendedValidatorTests.groovy
@@ -1,0 +1,29 @@
+import net.zorched.test.HasExtendedValidators
+import org.junit.Test
+
+class ExtendedValidatorTests {
+    @Test
+    void testCodeReturnedFromValidator() {
+        def a = new HasExtendedValidators(foo:"bar")
+        a.validate()
+
+        assert a.errors.hasFieldErrors("foo")
+        assert a.errors.getFieldError("foo").code == "error.code"
+    }
+
+    @Test
+    void testCodeAndArgumentsFromValidator() {
+        def a = new HasExtendedValidators(bar:"foo")
+        a.validate()
+
+        assert a.errors.hasFieldErrors("bar")
+
+        def error = a.errors.getFieldError("bar")
+        assert error.code == "error.code"
+        assert error.arguments[0] == "bar"  // property name
+        assert error.arguments[1] == a.class     // constraint owning class
+        assert error.arguments[2] == "foo"  // property value
+        assert error.arguments[3] == "foo"  // custom param #1
+        assert error.arguments[4] == "bar"  // custom param #2
+    }
+}


### PR DESCRIPTION
Hi Geoff,

Here's another pull request for you.

This one changes DefaultConstraintClass to return an Object from call to validate closure. The CustomConstraintFactory is then given the ol' copy/paste treatment, taking the same validate result handling from grails-core (org.codehaus.groovy.grails.validation.ValidatorConstraint).

This means that the validate method can now return the following:
- Nothing - which is interpreted as no validation errors
- True/false, as before
- `String`, which represents message code
- `List`, with first element being message code, and following elements being message parameters.

With this the validate closure behaves almost identically to regular custom validators (http://www.grails.org/doc/latest/ref/Constraints/validator.html). The only exception being that the Constraints plugin doesn't ignore return value if the validate closure accepts 3 parameters. Let me know how you feel about this.

There's also some tests written for this new functionality, with none of the original tests needing any changes.
