### PR TITLE
Veto support for constraints

### DIFF
--- a/ConstraintsGrailsPlugin.groovy
+++ b/ConstraintsGrailsPlugin.groovy
@@ -127,12 +127,15 @@ class ConstraintsGrailsPlugin {
      */
     def setupConstraintProperties = { constraintClass ->
         Object params = null
+        boolean veto = false
         Object hibernateTemplate = null
         Object constraintOwningClass = null
         String constraintPropertyName = null
         constraintClass.clazz.metaClass {
             setParams = {val -> params = val}
             getParams = {-> return params}
+            setVeto = {boolean val -> veto = val}
+            getVeto = {-> veto }
             setHibernateTemplate = {val -> hibernateTemplate = val}
             getHibernateTemplate = {-> return hibernateTemplate}
             setConstraintOwningClass = {val -> constraintOwningClass = val}

--- a/grails-app/domain/net/zorched/test/Subjugated.groovy
+++ b/grails-app/domain/net/zorched/test/Subjugated.groovy
@@ -1,0 +1,9 @@
+package net.zorched.test
+
+class Subjugated {
+    String foo
+
+    static constraints = {
+        foo(powerHungry: true, beginsWith: "zzz")
+    }
+}

--- a/grails-app/utils/net/zorched/test/PowerHungryConstraint.groovy
+++ b/grails-app/utils/net/zorched/test/PowerHungryConstraint.groovy
@@ -1,0 +1,10 @@
+package net.zorched.test
+
+class PowerHungryConstraint {
+    static vetoer = true
+
+    def validate = { val ->
+        veto = true
+        return true
+    }
+}

--- a/src/java/net/zorched/grails/plugins/validation/DefaultGrailsConstraintClass.java
+++ b/src/java/net/zorched/grails/plugins/validation/DefaultGrailsConstraintClass.java
@@ -187,4 +187,24 @@ public class DefaultGrailsConstraintClass extends AbstractInjectableGrailsClass 
             throw new IllegalArgumentException("Not a supported type");
         }
     }
+
+    public void setVeto(boolean veto) {
+        getMetaClass().invokeMethod(getReferenceInstance(), "setVeto", veto);
+    }
+
+    public boolean getVeto() {
+        Boolean obj = (Boolean)getMetaClass().invokeMethod(getReferenceInstance(), "getVeto", new Object[] {});
+        if (obj != null) {
+            return obj;
+        }
+        return false;
+    }
+
+    public boolean isVetoer() {
+        Boolean obj = (Boolean) getPropertyValue(VETOER_PROPERTY);
+        if (obj != null) {
+            return obj;
+        }
+        return false;
+    }
 }

--- a/src/java/net/zorched/grails/plugins/validation/GrailsConstraintClass.java
+++ b/src/java/net/zorched/grails/plugins/validation/GrailsConstraintClass.java
@@ -39,6 +39,7 @@ public interface GrailsConstraintClass extends InjectableGrailsClass {
     public static final String FAILURE_CODE_PROPERTY = "failureCode";
 
     public static final String PERSISTENT_PROPERTY = "persistent";
+    public static final String VETOER_PROPERTY = "vetoer";
 
     public static final String VALIDATE = "validate";
     public static final String SUPPORTS = "supports";
@@ -98,4 +99,11 @@ public interface GrailsConstraintClass extends InjectableGrailsClass {
      * static persistent = false
      */
     public boolean isPersistent();
+
+    /**
+     * Can this constraint veto all following constraints?
+     * Defaults to false
+     * static veto = true
+     */
+    public boolean isVetoer();
 }

--- a/test/integration/VetoingConstraintTests.groovy
+++ b/test/integration/VetoingConstraintTests.groovy
@@ -1,0 +1,13 @@
+import org.junit.Test
+import net.zorched.test.Subjugated
+
+class VetoingConstraintTests {
+    @Test
+    void testVetoingConstraint() {
+        def a = new Subjugated(foo: "bar")
+
+        // This should pass because the vetoing constraint will not cause a validation error, and should cease all
+        // further validation.
+        assert a.validate()
+    }
+}


### PR DESCRIPTION
Hi Geoff,

One more pull request for you, this will probably be the last one for now!

This patch gives constraints the ability to **veto** any further constraints from validating a field. This concept is something that isn't actually possible in standard Grails custom validators (to my knowledge), but does exist and is used in the grails core - primarily for things like the nullable constraint.

If you're wondering where something like vetoing might be handy, consider this:

```
class Foo {
    String date

    static constraints = {
        date(validDate: true, validation: { val ->
            // Some code to make sure the date is in
            // the future, or something.
        }
    }
}

// ... 

class ValidDateConstraint {
    static vetoer = true

    def validate = { val ->
        if(!parseDate(val)) {
            veto = true
            return false
        }
    }
}
```

As you can see, the ValidDateConstraint has indicated that it wishes to be able to veto subsequent constraints, and has exercised that veto power when it determines that a date isn't valid. This means that the custom validation written in Foo constraints will not execute _at all_ unless a valid date has been provided. Without vetoing, if a user were to provide an invalid date, they would receive two errors, one for the fact that they have an invalid date, and another stating that the (not yet valid) date is not in the future.

I feel that exposing veto capabilities to Constraints makes them much more composable, you could have a group of custom validations that run against a single field and work well together. Of course, sometimes it might make sense to present multiple validation fails on a single field, if the errors are pertinent enough. Veto support just gives developers the flexibility to decide that for themselves.

The code is commented and has a test written for it. Let me know if you need anything else, or want to discuss this concept further.
