### PR TITLE
@TestMixin support for constraint unit testing

### DIFF
--- a/src/groovy/net/zorched/grails/plugins/validation/ConstraintUnitTestMixin.groovy
+++ b/src/groovy/net/zorched/grails/plugins/validation/ConstraintUnitTestMixin.groovy
@@ -14,10 +14,10 @@ class ConstraintUnitTestMixin extends GrailsUnitTestMixin {
     def <T> T mockConstraint(Class<T> constraintClass) {
         def instance = constraintClass.newInstance()
 
-        instance.metaClass.getParams = {-> params }
-        instance.metaClass.setParams = {newParams -> params = newParams }
-        instance.metaClass.getVeto = {-> veto }
-        instance.metaClass.setVeto = {newVeto -> veto = newVeto }
+        constraintClass.metaClass.getParams = {-> params }
+        constraintClass.metaClass.setParams = {newParams -> params = newParams }
+        constraintClass.metaClass.getVeto = {-> veto }
+        constraintClass.metaClass.setVeto = {newVeto -> veto = newVeto }
 
         return instance
     }

--- a/src/groovy/net/zorched/grails/plugins/validation/ConstraintUnitTestMixin.groovy
+++ b/src/groovy/net/zorched/grails/plugins/validation/ConstraintUnitTestMixin.groovy
@@ -1,0 +1,30 @@
+package net.zorched.grails.plugins.validation
+
+import grails.test.mixin.support.GrailsUnitTestMixin
+import org.junit.After
+
+class ConstraintUnitTestMixin extends GrailsUnitTestMixin {
+    def params = [:]
+    def veto = null
+
+    def <T> T testFor(Class<T> constraintClass) {
+        return this.mockConstraint(constraintClass)
+    }
+
+    def <T> T mockConstraint(Class<T> constraintClass) {
+        def instance = constraintClass.newInstance()
+
+        instance.metaClass.getParams = {-> params }
+        instance.metaClass.setParams = {newParams -> params = newParams }
+        instance.metaClass.getVeto = {-> veto }
+        instance.metaClass.setVeto = {newVeto -> veto = newVeto }
+
+        return instance
+    }
+
+    @After
+    void resetFields() {
+        params = [:]
+        veto = null
+    }
+}


### PR DESCRIPTION
Hi Geoff,

Another patch for you. This one focuses on making unit testing constraints more pleasant in Grails 2.

A new class has been created, ConstraintUnitTestMixin. This class extends from GrailsUnitTestMixin, this follows the convention of the built-in unit test mixins for [Controllers](https://github.com/grails/grails-core/blob/master/grails-plugin-testing/src/main/groovy/grails/test/mixin/web/ControllerUnitTestMixin.groovy)/[Services](https://github.com/grails/grails-core/blob/master/grails-plugin-testing/src/main/groovy/grails/test/mixin/services/ServiceUnitTestMixin.groovy)/etc.

Using this class is simple, here's an example:

```
@TestMixin(ConstraintUnitTestMixin)
class MyConstraintTests {
    void testStuff() {
        def constraint = testFor(MyConstraint)

        // Params are automatically mixed in to the test class and exposed
        // to the constraint with the call above.
        params.foo = "bar"

        assert constraint.validate("foo", null, null) == true
    }
}
```

Note that the meta-class is being modified on every call to testFor(), this is deliberate, as GrailsUnitTestMixin listens for changes to meta-classes and rolls them back between tests. Nifty huh?

Let me know what you think!
