### PR TITLE
Constraint API + concurrency fixes

### DIFF
--- a/src/groovy/net/zorched/grails/plugins/validation/ConstraintApi.groovy
+++ b/src/groovy/net/zorched/grails/plugins/validation/ConstraintApi.groovy
@@ -1,0 +1,8 @@
+package net.zorched.grails.plugins.validation
+
+interface ConstraintApi {
+    Object getParams(Object instance)
+    Object getHibernateTemplate(Object instance)
+    Class getConstraintOwningClass(Object instance)
+    String getConstraintPropertyName(Object instance)
+}

--- a/src/groovy/net/zorched/grails/plugins/validation/ConstraintUnitTestMixin.groovy
+++ b/src/groovy/net/zorched/grails/plugins/validation/ConstraintUnitTestMixin.groovy
@@ -2,10 +2,12 @@ package net.zorched.grails.plugins.validation
 
 import grails.test.mixin.support.GrailsUnitTestMixin
 import org.junit.After
+import org.codehaus.groovy.grails.commons.metaclass.MetaClassEnhancer
 
 class ConstraintUnitTestMixin extends GrailsUnitTestMixin {
     def params = [:]
-    def veto = null
+    def constraintOwningClass = null
+    def constraintPropertyName = null
 
     def <T> T testFor(Class<T> constraintClass) {
         return this.mockConstraint(constraintClass)
@@ -13,18 +15,18 @@ class ConstraintUnitTestMixin extends GrailsUnitTestMixin {
 
     def <T> T mockConstraint(Class<T> constraintClass) {
         def instance = constraintClass.newInstance()
-
-        constraintClass.metaClass.getParams = {-> params }
-        constraintClass.metaClass.setParams = {newParams -> params = newParams }
-        constraintClass.metaClass.getVeto = {-> veto }
-        constraintClass.metaClass.setVeto = {newVeto -> veto = newVeto }
+        
+        MetaClassEnhancer enhancer = new MetaClassEnhancer()
+        enhancer.addApi(new MockConstraintApi(this))
+        enhancer.enhance(constraintClass.metaClass)
 
         return instance
     }
 
     @After
     void resetFields() {
-        params = [:]
-        veto = null
+        this.params = [:]
+        this.constraintOwningClass = null
+        this.constraintPropertyName = null
     }
 }

--- a/src/groovy/net/zorched/grails/plugins/validation/MockConstraintApi.groovy
+++ b/src/groovy/net/zorched/grails/plugins/validation/MockConstraintApi.groovy
@@ -1,0 +1,33 @@
+package net.zorched.grails.plugins.validation
+
+/**
+ * The unit test implementation of ConstraintApi. Which just uses instance variables to implement the Api.
+ * TODO: is this safe? How many people out there are using multithreaded test runners?
+ */
+class MockConstraintApi implements ConstraintApi {
+    def owner
+
+    MockConstraintApi(owner) {
+        this.owner = owner
+    }
+
+    @Override
+    Object getParams(Object instance) {
+        return this.owner.params
+    }
+
+    @Override
+    Object getHibernateTemplate(Object instance) {
+        return null
+    }
+
+    @Override
+    Class getConstraintOwningClass(Object instance) {
+        return this.owner.constraintOwningClass ?: null
+    }
+
+    @Override
+    String getConstraintPropertyName(Object instance) {
+        return this.owner.constraintPropertyName ?: null
+    }
+}

--- a/src/groovy/net/zorched/grails/plugins/validation/RequestConstraintApi.groovy
+++ b/src/groovy/net/zorched/grails/plugins/validation/RequestConstraintApi.groovy
@@ -1,0 +1,46 @@
+package net.zorched.grails.plugins.validation
+
+import org.codehaus.groovy.grails.commons.GrailsApplication
+import org.codehaus.groovy.grails.plugins.support.aware.GrailsApplicationAware
+import org.codehaus.groovy.grails.web.servlet.mvc.GrailsWebRequest
+import org.springframework.web.context.request.ServletRequestAttributes
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.orm.hibernate3.HibernateTemplate
+import org.hibernate.SessionFactory
+
+/**
+ * The runtime implementation for ConstraintApi, which fetches information from the constraint stored in request attrs.
+ */
+class RequestConstraintApi implements ConstraintApi, GrailsApplicationAware {
+    public static String CONSTRAINT_REQUEST_ATTRIBUTE = "grails-constraints_constraint"
+
+    GrailsApplication grailsApplication
+
+    @Override
+    Object getParams(Object instance) {
+        return constraint.parameter
+    }
+
+    @Override
+    Object getHibernateTemplate(Object instance) {
+        if(grailsApplication.mainContext.containsBean("sessionFactory")) {
+            return new HibernateTemplate(grailsApplication.mainContext.sessionFactory, true)
+        }
+
+        return null
+    }
+
+    @Override
+    Class getConstraintOwningClass(Object instance) {
+        return constraint.constraintOwningClass
+    }
+
+    @Override
+    String getConstraintPropertyName(Object instance) {
+        return constraint.propertyName
+    }
+
+    CustomConstraintFactory.CustomConstraintClass getConstraint() {
+        return RequestContextHolder.currentRequestAttributes().getAttribute(CONSTRAINT_REQUEST_ATTRIBUTE, 0)
+    }
+}

--- a/src/java/net/zorched/grails/plugins/validation/CustomConstraintFactory.java
+++ b/src/java/net/zorched/grails/plugins/validation/CustomConstraintFactory.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.validation.Errors;
+import org.springframework.web.context.request.RequestContextHolder;
 
 
 import java.lang.reflect.Method;
@@ -75,13 +76,7 @@ public class CustomConstraintFactory implements ConstraintFactory {
             if (validationParamCount > 2)
                 params.add(errors);
 
-            // Setup parameters needed by constraints
-            constraint.setParameter(constraintParameter);
-            constraint.setConstraintOwningClass(constraintOwningClass);
-            constraint.setConstraintPropertyName(constraintPropertyName);
-            if (constraint.isPersistent()) {
-                constraint.setHibernateTemplate(applicationContext);
-            }
+            RequestContextHolder.currentRequestAttributes().setAttribute(RequestConstraintApi.CONSTRAINT_REQUEST_ATTRIBUTE, this, 0);
 
             // Inject dependencies
             applicationContext.getAutowireCapableBeanFactory().autowireBeanProperties(constraint.getReferenceInstance(), AutowireCapableBeanFactory.AUTOWIRE_BY_NAME, false);
@@ -148,6 +143,10 @@ public class CustomConstraintFactory implements ConstraintFactory {
 
         protected boolean skipNullValues() {
             return constraint.skipNullValues();
+        }
+        
+        public Class getConstraintOwningClass() {
+            return this.constraintOwningClass;
         }
 
         public void setParameter(Object constraintParameter) {

--- a/src/java/net/zorched/grails/plugins/validation/DefaultGrailsConstraintClass.java
+++ b/src/java/net/zorched/grails/plugins/validation/DefaultGrailsConstraintClass.java
@@ -79,42 +79,6 @@ public class DefaultGrailsConstraintClass extends AbstractInjectableGrailsClass 
         return c.getMaximumNumberOfParameters();
     }
 
-    /**
-     * The value that was passed to the constraint parameter. This will be available as
-     * 'params' in a constraint.
-     * @param constraintParameter The value to make available in params
-     */
-    public void setParameter(Object constraintParameter) {
-        getMetaClass().invokeMethod(getReferenceInstance(), "setParams", constraintParameter);
-    }
-
-    /**
-     * Make the hibernateTemplate available to persisent constraints
-     * @param applicationContext The application context used to lookup the hibernate SessionFactory
-     */
-    public void setHibernateTemplate(ApplicationContext applicationContext) {
-        if (applicationContext.containsBean("sessionFactory")) {
-            HibernateTemplate template = new HibernateTemplate((SessionFactory) applicationContext.getBean("sessionFactory"),true);
-            getMetaClass().invokeMethod(getReferenceInstance(), "setHibernateTemplate", template);
-        }
-    }
-
-    /**
-     * Make the owning class available to persistent constraints
-     * @param owningClass The class the constraint is applied to.
-     */
-    public void setConstraintOwningClass(Object owningClass) {
-        getMetaClass().invokeMethod(getReferenceInstance(), "setConstraintOwningClass", owningClass);
-    }
-
-    /**
-     * Make the property the constraint was applied to available to persistent constraints
-     * @param constrainedPropertyName The property the constraint is applied to.
-     */
-    public void setConstraintPropertyName(String constrainedPropertyName) {
-        getMetaClass().invokeMethod(getReferenceInstance(), "setConstraintPropertyName", constrainedPropertyName);
-    }
-
     public String getName() {
         return getConstraintName();
 	}


### PR DESCRIPTION
Hi Geoff,

This patch is a little bigger than the other one I just submitted. This one focuses on the way we enhance the metaClass for the purposes of the "magic" stuff available in validate closure (params/hibernateTemplate/etc).

The issue is, the way it's currently implemented is inherently not thread-safe. This is because a single instance of DefaultGrailsConstraintClass (and the actual constraint class being wrapped) is shared across any number of applied constraints. Consider this example:

```
class AwesomeConstraint {
    def validate = { val ->
        return params == "foo"
    }
}

class FirstCommandObject {
    String blah

    static constraints = {
        blah(awesome: "foo")
    }
}

class SecondCommandObject {
    String blah

    static constraints = {
        blah(awesome: "bar")
    }
}
```

We would assume in this example that any time SecondCommandObject is used, it would be guaranteed to fail, however this is currently not the case. Instead, FirstCommandObject will sometimes sporadically fail, and SecondCommandObject will succeed. This is because the way setupConstraint was dishing out params and such was not thread safe.

So I've opted to implement the expected constraints validate api by stashing the CustomConstraintClass currently being executed in the request attributes of the current ServletRequest. The new api proxies requests for params/owningClass/propertyName/etc through the stashed CustomConstraintClass.

While I was doing this, I also refactored the api to be an interface, and the implementation will be applied to constraints using the Grails-y MetaClassEnhancer.

I also introduced another implementation of the ConstraintApi for test-mode, which will just proxy params and friends over to the test method that is currently executing. This means that accessing params/constraintOwningClass/etc will just access the same var that is injected into test classes via ConstraintsUnitTestMixin.

Please let me know if you have any questions!

-Sam
